### PR TITLE
use python3.7

### DIFF
--- a/docker/tsugi-pg4e-prepare.sh
+++ b/docker/tsugi-pg4e-prepare.sh
@@ -12,6 +12,10 @@ echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee /etc/
 
 apt-get update
 
+echo ======= Install Python3.7
+add-apt-repository -y ppa:deadsnakes/ppa
+apt install -y python3.7 python3.7-venv
+
 echo ======= Install PostgreSQL 11
 apt install -y sudo
 apt install -y postgresql-11 postgresql-contrib-11
@@ -22,7 +26,6 @@ echo ======= Install Elastic 7
 
 apt-get -y install openjdk-8-jdk
 
-apt-get install -y python3-venv
 apt-get install -y nodejs
 apt-get install -y npm
 apt-get install -y apt-transport-https
@@ -35,7 +38,7 @@ git clone https://github.com/csev/charles-server.git
 cd charles-server
 
 echo ====== Making virtual environment
-python3 -m venv .venv
+python3.7 -m venv .venv
 source .venv/bin/activate
 
 # Get the latest pip

--- a/docker/tsugi-pg4e-startup.sh
+++ b/docker/tsugi-pg4e-startup.sh
@@ -27,6 +27,10 @@ if [ -z "$CHARLES_AUTH_SECRET" ]; then
 CHARLES_AUTH_SECRET=12345; export CHARLES_AUTH_SECRET;
 fi
 
+if [-z "$CHARLES_POSTGRES_DATABASE" ]; then
+CHARLES_POSTGRES_DATABASE=charles; export CHARLES_POSTGRES_DATABASE;
+fi
+
 COMPLETE=/usr/local/bin/tsugi-pg4e-complete
 if [ -f "$COMPLETE" ]; then
     echo "Starting charles-server"
@@ -61,7 +65,7 @@ cd /var/www/html/
 git clone https://github.com/csev/phppgadmin.git
 cp /var/www/html/scripts/config.inc.php /var/www/html/phppgadmin/conf/config.inc.php
 
-cat >> /var/www/html/tsugi/config.php << EOF 
+cat >> /var/www/html/tsugi/config.php << EOF
 \$CFG->tool_folders = array("admin", "../tools", "mod");
 \$CFG->psql_root_password = "$PSQL_ROOT_PASSWORD";
 
@@ -141,4 +145,3 @@ exec bash /usr/local/bin/monitor-apache.sh
 # https://stackoverflow.com/questions/2935183/bash-infinite-sleep-infinite-blocking
 echo "Tsugi PG4E Sleeping forever..."
 while :; do sleep 2073600; done
-


### PR DESCRIPTION
Use `python3.7` to run `charles-server` so `datetime.fromisoformat` is available, as it depends on this function. `datetime.fromisoformat` is not available prior to `python3.7`.